### PR TITLE
feat: Docker + Build output path

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+dist
+.git
+.gitignore
+Dockerfile
+docker-compose.yml
+README.md
+*.log

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ pids
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+
+tsconfig.build.tsbuildinfo

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm ci
+
+COPY . .
+
+RUN npm run build
+
+FROM node:22-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm ci --only=production
+
+COPY --from=builder /app/dist ./dist
+
+CMD ["node", "dist/main.js"]

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,5 @@
 {
   "extends": "./tsconfig.json",
+  "include": ["src/**/*"],
   "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
 }


### PR DESCRIPTION
Since the app was dockerized, I realized that has the 'src' sub-folder under '.dist/' after building it. 
Changes:

1. Remove the intermediate src folder under '.dist' directory.
2. Add Multi Stage/Layer Dockerfile taking care of Docker cache